### PR TITLE
Add macOS compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "FF7 memory manipulation and data structures library"
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-winapi = { version = "0.3", features = ["memoryapi", "winnt", "winuser", "processthreadsapi", "handleapi"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "=0.30.12"
@@ -17,6 +16,9 @@ lazy_static = "1.5.0"
 parking_lot = "0.12.3" 
 flate2 = "1.0"
 byteorder = "1.5.0"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["memoryapi", "winnt", "winuser", "processthreadsapi", "handleapi"] }
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -99,7 +99,7 @@ impl ProcessScanner {
                 match found_process {
                     Some(pid) => {
                         if info.handle.is_none() || info.previous_pid != Some(pid) {
-                            let proc_pid: ProcPid = pid.as_u32().into();
+                            let proc_pid: ProcPid = (pid.as_u32() as i32).into();
                             info.handle = proc_pid.try_into_process_handle().ok();
                         }
                     }


### PR DESCRIPTION
**ff7-landscaper**
- Update Tauri bundle targets for macOS (app instead of nsis)

**ff7-lib**
- Make winapi dependency Windows-only in ff7-lib
- Add platform-specific compilation guards for memory functions
- Fix process ID type conversion (u32 to i32)
- Add local development override with .cargo/config.toml (eg, in the main cargo, it was a path reference)